### PR TITLE
move dependecies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": "^8.1.4"
   },
-  "dependencies": {
+  "devDependencies": {
     "body-parser": "^1.14.1",
     "del": "^3.0.0",
     "express": "^4.16.2",
@@ -24,6 +24,7 @@
     "nunjucks": "^3.0.0",
     "run-sequence": "^1.2.2"
   },
+  "dependencies": {},
   "scripts": {
     "pretest": "npm run lint --silent",
     "test": "standard && gulp test",


### PR DESCRIPTION
By moving all `dependencies` to `devDependencies`, we can avoid installing extraneous, dev-specific packages when consuming this package.